### PR TITLE
Remove obsolete fields

### DIFF
--- a/alpha/template/composite/builder_test.go
+++ b/alpha/template/composite/builder_test.go
@@ -36,11 +36,7 @@ func TestBasicBuilder(t *testing.T) {
 			name:     "successful basic build yaml output",
 			validate: true,
 			basicBuilder: NewBasicBuilder(BuilderConfig{
-				ContainerCfg: ContainerConfig{
-					ContainerTool: "docker",
-					BaseImage:     "quay.io/operator-framework/opm:latest",
-					WorkingDir:    testDir,
-				},
+				WorkingDir:    testDir,
 				OutputType: "yaml",
 			}),
 			templateDefinition: TemplateDefinition{
@@ -71,11 +67,7 @@ func TestBasicBuilder(t *testing.T) {
 			name:     "successful basic build json output",
 			validate: true,
 			basicBuilder: NewBasicBuilder(BuilderConfig{
-				ContainerCfg: ContainerConfig{
-					ContainerTool: "docker",
-					BaseImage:     "quay.io/operator-framework/opm:latest",
-					WorkingDir:    testDir,
-				},
+				WorkingDir:    testDir,
 				OutputType: "json",
 			}),
 			templateDefinition: TemplateDefinition{
@@ -106,11 +98,7 @@ func TestBasicBuilder(t *testing.T) {
 			name:     "invalid template configuration",
 			validate: false,
 			basicBuilder: NewBasicBuilder(BuilderConfig{
-				ContainerCfg: ContainerConfig{
-					ContainerTool: "docker",
-					BaseImage:     "quay.io/operator-framework/opm:latest",
-					WorkingDir:    testDir,
-				},
+				WorkingDir:    testDir,
 				OutputType: "yaml",
 			}),
 			templateDefinition: TemplateDefinition{
@@ -129,11 +117,7 @@ func TestBasicBuilder(t *testing.T) {
 			name:     "invalid output type",
 			validate: false,
 			basicBuilder: NewBasicBuilder(BuilderConfig{
-				ContainerCfg: ContainerConfig{
-					ContainerTool: "docker",
-					BaseImage:     "quay.io/operator-framework/opm:latest",
-					WorkingDir:    testDir,
-				},
+				WorkingDir:    testDir,
 				OutputType: "invalid",
 			}),
 			templateDefinition: TemplateDefinition{
@@ -152,11 +136,7 @@ func TestBasicBuilder(t *testing.T) {
 			name:     "invalid schema",
 			validate: false,
 			basicBuilder: NewBasicBuilder(BuilderConfig{
-				ContainerCfg: ContainerConfig{
-					ContainerTool: "docker",
-					BaseImage:     "quay.io/operator-framework/opm:latest",
-					WorkingDir:    testDir,
-				},
+				WorkingDir:    testDir,
 				OutputType: "yaml",
 			}),
 			templateDefinition: TemplateDefinition{
@@ -172,11 +152,7 @@ func TestBasicBuilder(t *testing.T) {
 			name:     "template config has empty input",
 			validate: false,
 			basicBuilder: NewBasicBuilder(BuilderConfig{
-				ContainerCfg: ContainerConfig{
-					ContainerTool: "docker",
-					BaseImage:     "quay.io/operator-framework/opm:latest",
-					WorkingDir:    testDir,
-				},
+				WorkingDir:    testDir,
 				OutputType: "yaml",
 			}),
 			templateDefinition: TemplateDefinition{
@@ -197,11 +173,7 @@ func TestBasicBuilder(t *testing.T) {
 			name:     "template config has empty output",
 			validate: false,
 			basicBuilder: NewBasicBuilder(BuilderConfig{
-				ContainerCfg: ContainerConfig{
-					ContainerTool: "docker",
-					BaseImage:     "quay.io/operator-framework/opm:latest",
-					WorkingDir:    testDir,
-				},
+				WorkingDir:    testDir,
 				OutputType: "yaml",
 			}),
 			templateDefinition: TemplateDefinition{
@@ -222,11 +194,7 @@ func TestBasicBuilder(t *testing.T) {
 			name:     "template config has empty input & output",
 			validate: false,
 			basicBuilder: NewBasicBuilder(BuilderConfig{
-				ContainerCfg: ContainerConfig{
-					ContainerTool: "docker",
-					BaseImage:     "quay.io/operator-framework/opm:latest",
-					WorkingDir:    testDir,
-				},
+				WorkingDir:    testDir,
 				OutputType: "yaml",
 			}),
 			templateDefinition: TemplateDefinition{
@@ -446,11 +414,7 @@ func TestSemverBuilder(t *testing.T) {
 			name:     "successful semver build yaml output",
 			validate: true,
 			semverBuilder: NewSemverBuilder(BuilderConfig{
-				ContainerCfg: ContainerConfig{
-					ContainerTool: "docker",
-					BaseImage:     "quay.io/operator-framework/opm:latest",
-					WorkingDir:    testDir,
-				},
+				WorkingDir:    testDir,
 				OutputType: "yaml",
 			}),
 			templateDefinition: TemplateDefinition{
@@ -481,11 +445,7 @@ func TestSemverBuilder(t *testing.T) {
 			name:     "successful semver build json output",
 			validate: true,
 			semverBuilder: NewSemverBuilder(BuilderConfig{
-				ContainerCfg: ContainerConfig{
-					ContainerTool: "docker",
-					BaseImage:     "quay.io/operator-framework/opm:latest",
-					WorkingDir:    testDir,
-				},
+				WorkingDir:    testDir,
 				OutputType: "json",
 			}),
 			templateDefinition: TemplateDefinition{
@@ -516,11 +476,7 @@ func TestSemverBuilder(t *testing.T) {
 			name:     "invalid template configuration",
 			validate: false,
 			semverBuilder: NewSemverBuilder(BuilderConfig{
-				ContainerCfg: ContainerConfig{
-					ContainerTool: "docker",
-					BaseImage:     "quay.io/operator-framework/opm:latest",
-					WorkingDir:    testDir,
-				},
+				WorkingDir:    testDir,
 				OutputType: "yaml",
 			}),
 			templateDefinition: TemplateDefinition{
@@ -539,11 +495,7 @@ func TestSemverBuilder(t *testing.T) {
 			name:     "invalid output type",
 			validate: false,
 			semverBuilder: NewSemverBuilder(BuilderConfig{
-				ContainerCfg: ContainerConfig{
-					ContainerTool: "docker",
-					BaseImage:     "quay.io/operator-framework/opm:latest",
-					WorkingDir:    testDir,
-				},
+				WorkingDir:    testDir,
 				OutputType: "invalid",
 			}),
 			templateDefinition: TemplateDefinition{
@@ -562,11 +514,7 @@ func TestSemverBuilder(t *testing.T) {
 			name:     "invalid schema",
 			validate: false,
 			semverBuilder: NewSemverBuilder(BuilderConfig{
-				ContainerCfg: ContainerConfig{
-					ContainerTool: "docker",
-					BaseImage:     "quay.io/operator-framework/opm:latest",
-					WorkingDir:    testDir,
-				},
+				WorkingDir:    testDir,
 				OutputType: "yaml",
 			}),
 			templateDefinition: TemplateDefinition{
@@ -583,11 +531,7 @@ func TestSemverBuilder(t *testing.T) {
 			name:     "template config has empty input",
 			validate: false,
 			semverBuilder: NewSemverBuilder(BuilderConfig{
-				ContainerCfg: ContainerConfig{
-					ContainerTool: "docker",
-					BaseImage:     "quay.io/operator-framework/opm:latest",
-					WorkingDir:    testDir,
-				},
+				WorkingDir:    testDir,
 				OutputType: "yaml",
 			}),
 			templateDefinition: TemplateDefinition{
@@ -608,11 +552,7 @@ func TestSemverBuilder(t *testing.T) {
 			name:     "template config has empty output",
 			validate: false,
 			semverBuilder: NewSemverBuilder(BuilderConfig{
-				ContainerCfg: ContainerConfig{
-					ContainerTool: "docker",
-					BaseImage:     "quay.io/operator-framework/opm:latest",
-					WorkingDir:    testDir,
-				},
+				WorkingDir:    testDir,
 				OutputType: "yaml",
 			}),
 			templateDefinition: TemplateDefinition{
@@ -633,11 +573,7 @@ func TestSemverBuilder(t *testing.T) {
 			name:     "template config has empty input & output",
 			validate: false,
 			semverBuilder: NewSemverBuilder(BuilderConfig{
-				ContainerCfg: ContainerConfig{
-					ContainerTool: "docker",
-					BaseImage:     "quay.io/operator-framework/opm:latest",
-					WorkingDir:    testDir,
-				},
+				WorkingDir:    testDir,
 				OutputType: "yaml",
 			}),
 			templateDefinition: TemplateDefinition{
@@ -867,11 +803,7 @@ func TestRawBuilder(t *testing.T) {
 			name:     "successful raw build yaml output",
 			validate: true,
 			rawBuilder: NewRawBuilder(BuilderConfig{
-				ContainerCfg: ContainerConfig{
-					ContainerTool: "docker",
-					BaseImage:     "quay.io/operator-framework/opm:latest",
-					WorkingDir:    testDir,
-				},
+				WorkingDir:    testDir,
 				OutputType: "yaml",
 			}),
 			templateDefinition: TemplateDefinition{
@@ -902,11 +834,7 @@ func TestRawBuilder(t *testing.T) {
 			name:     "successful raw build json output",
 			validate: true,
 			rawBuilder: NewRawBuilder(BuilderConfig{
-				ContainerCfg: ContainerConfig{
-					ContainerTool: "docker",
-					BaseImage:     "quay.io/operator-framework/opm:latest",
-					WorkingDir:    testDir,
-				},
+				WorkingDir:    testDir,
 				OutputType: "json",
 			}),
 			templateDefinition: TemplateDefinition{
@@ -937,11 +865,7 @@ func TestRawBuilder(t *testing.T) {
 			name:     "invalid template configuration",
 			validate: false,
 			rawBuilder: NewRawBuilder(BuilderConfig{
-				ContainerCfg: ContainerConfig{
-					ContainerTool: "docker",
-					BaseImage:     "quay.io/operator-framework/opm:latest",
-					WorkingDir:    testDir,
-				},
+				WorkingDir:    testDir,
 				OutputType: "yaml",
 			}),
 			templateDefinition: TemplateDefinition{
@@ -960,11 +884,7 @@ func TestRawBuilder(t *testing.T) {
 			name:     "invalid output type",
 			validate: false,
 			rawBuilder: NewRawBuilder(BuilderConfig{
-				ContainerCfg: ContainerConfig{
-					ContainerTool: "docker",
-					BaseImage:     "quay.io/operator-framework/opm:latest",
-					WorkingDir:    testDir,
-				},
+				WorkingDir:    testDir,
 				OutputType: "invalid",
 			}),
 			templateDefinition: TemplateDefinition{
@@ -983,11 +903,7 @@ func TestRawBuilder(t *testing.T) {
 			name:     "invalid schema",
 			validate: false,
 			rawBuilder: NewRawBuilder(BuilderConfig{
-				ContainerCfg: ContainerConfig{
-					ContainerTool: "docker",
-					BaseImage:     "quay.io/operator-framework/opm:latest",
-					WorkingDir:    testDir,
-				},
+				WorkingDir:    testDir,
 				OutputType: "yaml",
 			}),
 			templateDefinition: TemplateDefinition{
@@ -1003,11 +919,7 @@ func TestRawBuilder(t *testing.T) {
 			name:     "template config has empty input",
 			validate: false,
 			rawBuilder: NewRawBuilder(BuilderConfig{
-				ContainerCfg: ContainerConfig{
-					ContainerTool: "docker",
-					BaseImage:     "quay.io/operator-framework/opm:latest",
-					WorkingDir:    testDir,
-				},
+				WorkingDir:    testDir,
 				OutputType: "yaml",
 			}),
 			templateDefinition: TemplateDefinition{
@@ -1028,11 +940,7 @@ func TestRawBuilder(t *testing.T) {
 			name:     "template config has empty output",
 			validate: false,
 			rawBuilder: NewRawBuilder(BuilderConfig{
-				ContainerCfg: ContainerConfig{
-					ContainerTool: "docker",
-					BaseImage:     "quay.io/operator-framework/opm:latest",
-					WorkingDir:    testDir,
-				},
+				WorkingDir:    testDir,
 				OutputType: "yaml",
 			}),
 			templateDefinition: TemplateDefinition{
@@ -1053,11 +961,7 @@ func TestRawBuilder(t *testing.T) {
 			name:     "template config has empty input & output",
 			validate: false,
 			rawBuilder: NewRawBuilder(BuilderConfig{
-				ContainerCfg: ContainerConfig{
-					ContainerTool: "docker",
-					BaseImage:     "quay.io/operator-framework/opm:latest",
-					WorkingDir:    testDir,
-				},
+				WorkingDir:    testDir,
 				OutputType: "yaml",
 			}),
 			templateDefinition: TemplateDefinition{
@@ -1310,11 +1214,7 @@ func TestCustomBuilder(t *testing.T) {
 			name:     "successful custom build yaml output",
 			validate: true,
 			customBuilder: NewCustomBuilder(BuilderConfig{
-				ContainerCfg: ContainerConfig{
-					ContainerTool: "docker",
-					BaseImage:     "quay.io/operator-framework/opm:latest",
-					WorkingDir:    testDir,
-				},
+				WorkingDir:    testDir,
 				OutputType: "yaml",
 			}),
 			templateDefinition: TemplateDefinition{
@@ -1345,11 +1245,7 @@ func TestCustomBuilder(t *testing.T) {
 			name:     "successful custom build json output",
 			validate: true,
 			customBuilder: NewCustomBuilder(BuilderConfig{
-				ContainerCfg: ContainerConfig{
-					ContainerTool: "docker",
-					BaseImage:     "quay.io/operator-framework/opm:latest",
-					WorkingDir:    testDir,
-				},
+				WorkingDir:    testDir,
 				OutputType: "json",
 			}),
 			templateDefinition: TemplateDefinition{
@@ -1380,11 +1276,7 @@ func TestCustomBuilder(t *testing.T) {
 			name:     "invalid template configuration",
 			validate: false,
 			customBuilder: NewCustomBuilder(BuilderConfig{
-				ContainerCfg: ContainerConfig{
-					ContainerTool: "docker",
-					BaseImage:     "quay.io/operator-framework/opm:latest",
-					WorkingDir:    testDir,
-				},
+				WorkingDir:    testDir,
 				OutputType: "yaml",
 			}),
 			templateDefinition: TemplateDefinition{
@@ -1403,11 +1295,7 @@ func TestCustomBuilder(t *testing.T) {
 			name:     "invalid schema",
 			validate: false,
 			customBuilder: NewCustomBuilder(BuilderConfig{
-				ContainerCfg: ContainerConfig{
-					ContainerTool: "docker",
-					BaseImage:     "quay.io/operator-framework/opm:latest",
-					WorkingDir:    testDir,
-				},
+				WorkingDir:    testDir,
 				OutputType: "yaml",
 			}),
 			templateDefinition: TemplateDefinition{
@@ -1427,11 +1315,7 @@ func TestCustomBuilder(t *testing.T) {
 			name:     "template config has empty command",
 			validate: false,
 			customBuilder: NewCustomBuilder(BuilderConfig{
-				ContainerCfg: ContainerConfig{
-					ContainerTool: "docker",
-					BaseImage:     "quay.io/operator-framework/opm:latest",
-					WorkingDir:    testDir,
-				},
+				WorkingDir:    testDir,
 				OutputType: "yaml",
 			}),
 			templateDefinition: TemplateDefinition{
@@ -1453,11 +1337,7 @@ func TestCustomBuilder(t *testing.T) {
 			name:     "template config has empty output",
 			validate: false,
 			customBuilder: NewCustomBuilder(BuilderConfig{
-				ContainerCfg: ContainerConfig{
-					ContainerTool: "docker",
-					BaseImage:     "quay.io/operator-framework/opm:latest",
-					WorkingDir:    testDir,
-				},
+				WorkingDir:    testDir,
 				OutputType: "yaml",
 			}),
 			templateDefinition: TemplateDefinition{
@@ -1479,11 +1359,7 @@ func TestCustomBuilder(t *testing.T) {
 			name:     "template config has empty command & output",
 			validate: false,
 			customBuilder: NewCustomBuilder(BuilderConfig{
-				ContainerCfg: ContainerConfig{
-					ContainerTool: "docker",
-					BaseImage:     "quay.io/operator-framework/opm:latest",
-					WorkingDir:    testDir,
-				},
+				WorkingDir:    testDir,
 				OutputType: "yaml",
 			}),
 			templateDefinition: TemplateDefinition{
@@ -1715,7 +1591,7 @@ const customBuiltFbcJson = `{
 `
 
 func TestValidateFailure(t *testing.T) {
-	err := validate(ContainerConfig{}, "")
+	err := validate(BuilderConfig{}, "")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "no such file or directory")
 }

--- a/alpha/template/composite/composite.go
+++ b/alpha/template/composite/composite.go
@@ -187,10 +187,6 @@ func (t *Template) newCatalogBuilderMap(catalogs []Catalog, outputType string) (
 			builderMap := make(BuilderMap)
 			for _, schema := range catalog.Builders {
 				builder, err := builderForSchema(schema, BuilderConfig{
-					ContainerCfg: ContainerConfig{
-						BaseImage:  catalog.Destination.BaseImage,
-						WorkingDir: catalog.Destination.WorkingDir,
-					},
 					OutputType: outputType,
 				})
 				if err != nil {

--- a/alpha/template/composite/composite_test.go
+++ b/alpha/template/composite/composite_test.go
@@ -251,7 +251,7 @@ func TestCompositeRender(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := tc.compositeTemplate.Render(context.Background(), &tc.compositeCfg, tc.validate)
+			err := tc.compositeTemplate.Render(context.Background(), tc.validate)
 			tc.assertions(t, err)
 		})
 	}


### PR DESCRIPTION
1. Remove `BuilderConfig.InputDirectory`
2. Remove `ContainerConfig` and move `ContainerConfig.WorkingDir` to `BuilderConfig`

Documentation and fix to composite_test.go are still missing.
